### PR TITLE
dbus-user.init: use bash instead of the user shell to run scripts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.6.0
 Package: osso-af-startup
 Architecture: all
 Pre-Depends: dpkg (>= 1.17.14)
-Depends: osso-af-utils (>= 1.16-1), dbus (>= 0.61-osso5), sudo, maemo-system-services (>= 0.5.0)
+Depends: osso-af-utils (>= 1.16-1), dbus (>= 0.61-osso5), sudo, maemo-system-services (>= 0.5.0), bash
 Description: Application framework top startup scripts
  Application framework startup scripts af-services, af-startup and
  af-base-apps. Also includes D-BUS session bus starting script.

--- a/debian/dbus-user.init
+++ b/debian/dbus-user.init
@@ -13,10 +13,10 @@ depend() {
 
 start() {
     ebegin "Starting dbus user session"
-    runuser - user /etc/osso-af-init/real-af-dbus start
+    runuser -ls /bin/bash user /etc/osso-af-init/real-af-dbus start
 }
 
 stop() {
     eend "Stopping dbus user session"
-    runuser - user /etc/osso-af-init/real-af-dbus stop
+    runuser -ls /bin/bash user /etc/osso-af-init/real-af-dbus stop
 }


### PR DESCRIPTION
This init script was broken whenever the user shell was not sh compatible as it used to execute the scripts with the users shell.
Note that i fixed the shell to be used as bash not sh as runuser relies on "soruce" being availble which is a bashism not availbe in plain sh or dash (the shell sh is linked to on leste) thus this package now depends on bash.

fixes https://github.com/maemo-leste/bugtracker/issues/709